### PR TITLE
Fix compile issue with gtk-4.15.0

### DIFF
--- a/src/gnome-online-accounts-gtk.c
+++ b/src/gnome-online-accounts-gtk.c
@@ -91,7 +91,11 @@ show_account (OaWindow   *window,
       goa_provider_show_account (provider,
                                  window->client,
                                  object,
+#if GTK_CHECK_VERSION(4, 15, 0)
+                                 GTK_WIDGET (window),
+#else
                                  GTK_WINDOW (window),
+#endif
                                  NULL,
                                  (GAsyncReadyCallback) show_account_cb,
                                  window);
@@ -131,7 +135,11 @@ add_account (OaWindow    *window,
 {
   goa_provider_add_account (provider,
                             window->client,
+#if GTK_CHECK_VERSION(4, 15, 0)
+                            GTK_WIDGET (window),
+#else
                             GTK_WINDOW (window),
+#endif
                             NULL,
                             (GAsyncReadyCallback) add_account_cb,
                             window);


### PR DESCRIPTION
Fixes the issue below

In file included from /usr/include/glib-2.0/gobject/gobject.h:26,
                 from /usr/include/glib-2.0/gobject/gbinding.h:31,
                 from /usr/include/glib-2.0/glib-object.h:24,
                 from /usr/include/gtk-4.0/gtk/css/gtkcssenumtypes.h:11,
                 from /usr/include/gtk-4.0/gtk/css/gtkcss.h:33,
                 from /usr/include/gtk-4.0/gtk/gtk.h:29,
                 from ../src/gnome-online-accounts-gtk.c:5:
../src/gnome-online-accounts-gtk.c: In function ‘show_account’:
/usr/include/glib-2.0/gobject/gtype.h:2656:42: error: passing argument 4 of ‘goa_provider_show_account’ from incompatible pointer type [-Wincompatible-pointer-types]
 2656 | #  define _G_TYPE_CIC(ip, gt, ct)       ((ct*) (void *) ip)
/usr/include/glib-2.0/gobject/gtype.h:528:66: note: in expansion of macro ‘_G_TYPE_CIC’
  528 | #define G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type)    (_G_TYPE_CIC ((instance), (g_type), c_type))
      |                                                                  ^~~~~~~~~~~
/usr/include/gtk-4.0/gtk/gtkwindow.h:39:42: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
   39 | #define GTK_WINDOW(obj)                 (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
../src/gnome-online-accounts-gtk.c:94:34: note: in expansion of macro ‘GTK_WINDOW’
   94 |                                  GTK_WINDOW (window),
      |                                  ^~~~~~~~~~
In file included from /usr/include/goa-1.0/goabackend/goabackend.h:29,
                 from ../src/gnome-online-accounts-gtk.c:12:
/usr/include/goa-1.0/goabackend/goaprovider.h:81:91: note: expected ‘GtkWidget *’ {aka ‘struct _GtkWidget *’} but argument is of type ‘GtkWindow *’ {aka ‘struct _GtkWindow *’}
   81 |                                                                   GtkWidget              *parent,
      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
../src/gnome-online-accounts-gtk.c: In function ‘add_account’:
/usr/include/glib-2.0/gobject/gtype.h:2656:42: error: passing argument 3 of ‘goa_provider_add_account’ from incompatible pointer type [-Wincompatible-pointer-types]
 2656 | #  define _G_TYPE_CIC(ip, gt, ct)       ((ct*) (void *) ip)
/usr/include/glib-2.0/gobject/gtype.h:528:66: note: in expansion of macro ‘_G_TYPE_CIC’
  528 | #define G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type)    (_G_TYPE_CIC ((instance), (g_type), c_type))
      |                                                                  ^~~~~~~~~~~
/usr/include/gtk-4.0/gtk/gtkwindow.h:39:42: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
   39 | #define GTK_WINDOW(obj)                 (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
../src/gnome-online-accounts-gtk.c:134:29: note: in expansion of macro ‘GTK_WINDOW’
  134 |                             GTK_WINDOW (window),
      |                             ^~~~~~~~~~
/usr/include/goa-1.0/goabackend/goaprovider.h:59:91: note: expected ‘GtkWidget *’ {aka ‘struct _GtkWidget *’} but argument is of type ‘GtkWindow *’ {aka ‘struct _GtkWindow *’}
   59 |                                                                   GtkWidget              *parent,
      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
ninja: build stopped: subcommand failed.